### PR TITLE
Reduce Infix class declaration to one line

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,16 +1,1 @@
-class Infix:
-    COVERED = ["or", "add", "sub", "mul", 
-    "matmul", "truediv", "floordiv", "mod", 
-    "lshift", "rshift", "and", "xor"]
-    INITIALIZED = False
-    def __init__(self, func):
-        self.func = func
-        if(not Infix.INITIALIZED):
-            Infix.INITIALIZED = True
-            exec("".join(f"""
-def __r{operation}__(self, other):
-    return Infix(lambda var: self.func(other, var))
-def __{operation}__(self, other):
-    return self.func(other)
-            """ for operation in Infix.COVERED), globals(), method_dict := {})
-            [setattr(self.__class__, method_name, method) for method_name, method in method_dict.items()]
+Infix = type('Infix', (object,), {'COVERED': ["or", "add", "sub", "mul", "matmul", "truediv", "floordiv", "mod", "lshift", "rshift", "and", "xor"], 'INITIALIZED': False, '__init__': lambda self, func: ((setattr(self, "func", func), (setattr(Infix, "INITIALIZED", True), exec("".join(f"def __r{operation}__(self, other):\n\treturn Infix(lambda var: self.func(other, var))\ndef __{operation}__(self, other):\n\treturn self.func(other)\n" for operation in Infix.COVERED), globals(), method_dict := {}), [setattr(self.__class__, method_name, method) for method_name, method in method_dict.items()]) if not Infix.INITIALIZED else None), None)[-1]})


### PR DESCRIPTION
This ultimate one-liner can replace a long and boring Infix class declaration with a super cool and highly readable marvel of technology.